### PR TITLE
feat: add option to disable totals validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,43 @@ $invoice->invoiceTotals()
 
 > **Note**: When manually setting totals, they must match the calculated values from the items, or an exception will be thrown to ensure data integrity.
 
+### Custom Totals (Disabling Validation)
+
+If you need to use totals that differ from the calculated values (e.g., due to external business logic, special rounding rules, or integration with other systems), you can disable totals validation:
+
+```php
+// Disable totals validation to allow custom values
+$invoice->disableTotalsValidation();
+
+// Set custom totals that may differ from calculated values
+$invoice->invoiceTotals()
+    ->setTaxExclusiveAmount(230.0)    // Custom amount
+    ->setTaxInclusiveAmount(260.0)    // Custom amount
+    ->setTaxTotalAmount(30.0)         // Custom amount
+    ->setPayableAmount(260.0);        // Custom amount
+
+// Generate XML with custom totals
+$xml = $invoice->generateXml();
+
+// Re-enable validation if needed
+$invoice->enableTotalsValidation();
+```
+
+Alternative methods for controlling validation:
+
+```php
+// Using setTotalsValidation method
+$invoice->setTotalsValidation(false);  // Disable
+$invoice->setTotalsValidation(true);   // Enable
+
+// Method chaining is supported
+$invoice->disableTotalsValidation()
+        ->invoiceTotals()
+        ->setTaxExclusiveAmount(100.0);
+```
+
+> **Important**: Disabling validation only affects the cross-validation between totals and line items. Individual field validation (e.g., negative amounts) still applies.
+
 ## API Communication
 
 The `send()` method handles the complete flow:

--- a/examples/GenerateWithCustomTotals.php
+++ b/examples/GenerateWithCustomTotals.php
@@ -1,0 +1,149 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use JBadarneh\JoFotara\JoFotaraService;
+
+/**
+ * Example: Generate Invoice with Custom Totals
+ * 
+ * This example demonstrates how to disable totals validation
+ * to use custom totals that may differ from calculated values.
+ * 
+ * Use cases:
+ * - External business logic for rounding
+ * - Integration with accounting systems with different calculation rules
+ * - Special promotional pricing that affects totals
+ */
+
+$invoice = new JoFotaraService('your-client-id', 'your-client-secret');
+
+// Configure basic invoice information
+$invoice->basicInformation()
+    ->setInvoiceId('INV-CUSTOM-001')
+    ->setUuid('123e4567-e89b-12d3-a456-426614174000')
+    ->setIssueDate('16-02-2025')
+    ->setInvoiceType('general_sales')
+    ->cash()
+    ->setNote('Invoice with custom totals due to promotional pricing');
+
+// Set seller information
+$invoice->sellerInformation()
+    ->setName('Your Company Name')
+    ->setTin('123456789');
+
+// Set customer information
+$invoice->customerInformation()
+    ->setId('987654321', 'TIN')
+    ->setName('Customer Name')
+    ->setPostalCode('11937')
+    ->setCityCode('JO-AM');
+
+// Set supplier income source
+$invoice->supplierIncomeSource('123456789');
+
+// Add invoice items
+// Item 1: Standard pricing
+$invoice->items()
+    ->addItem('1')
+    ->setQuantity(2)
+    ->setUnitPrice(100.0)
+    ->setDescription('Premium Widget')
+    ->setDiscount(10.0)  // 10 JOD discount
+    ->tax(16);
+
+// Item 2: Another item
+$invoice->items()
+    ->addItem('2')
+    ->setQuantity(1)
+    ->setUnitPrice(50.0)
+    ->setDescription('Basic Widget')
+    ->tax(16);
+
+// Calculated totals would be:
+// Item 1: (2 * 100) - 10 = 190 (tax exclusive), tax = 190 * 0.16 = 30.4, total = 220.4
+// Item 2: 50 (tax exclusive), tax = 50 * 0.16 = 8, total = 58
+// Combined: tax exclusive = 240, tax = 38.4, tax inclusive = 278.4
+
+echo "=== Standard Invoice (with validation) ===\n";
+try {
+    // This would use calculated totals automatically
+    $invoice->invoiceTotals();
+    $xml = $invoice->generateXml();
+    echo "✓ Generated successfully with calculated totals\n";
+} catch (Exception $e) {
+    echo "✗ Error: " . $e->getMessage() . "\n";
+}
+
+echo "\n=== Custom Totals (validation disabled) ===\n";
+
+// Now let's set custom totals that differ from calculated values
+// For example, due to a special promotion or external business logic
+
+// DISABLE totals validation to allow custom values
+$invoice->disableTotalsValidation();
+
+// Set custom totals (these differ from calculated values)
+$invoice->invoiceTotals()
+    ->setTaxExclusiveAmount(230.0)    // Custom: 230 instead of calculated 240
+    ->setTaxInclusiveAmount(260.0)    // Custom: 260 instead of calculated 278.4
+    ->setDiscountTotalAmount(10.0)    // Discount from items
+    ->setTaxTotalAmount(30.0)         // Custom: 30 instead of calculated 38.4
+    ->setPayableAmount(260.0);        // Custom: 260 instead of calculated 278.4
+
+try {
+    $xml = $invoice->generateXml();
+    echo "✓ Generated successfully with custom totals\n";
+    echo "Custom tax exclusive amount: 230.0 JOD\n";
+    echo "Custom tax inclusive amount: 260.0 JOD\n";
+    echo "Custom tax amount: 30.0 JOD\n";
+    
+    // Verify the XML contains our custom values
+    if (strpos($xml, '<cbc:TaxExclusiveAmount currencyID="JO">230.000000000</cbc:TaxExclusiveAmount>') !== false) {
+        echo "✓ Custom tax exclusive amount found in XML\n";
+    }
+    
+    if (strpos($xml, '<cbc:TaxInclusiveAmount currencyID="JO">260.000000000</cbc:TaxInclusiveAmount>') !== false) {
+        echo "✓ Custom tax inclusive amount found in XML\n";
+    }
+    
+} catch (Exception $e) {
+    echo "✗ Error: " . $e->getMessage() . "\n";
+}
+
+echo "\n=== Re-enabling Validation ===\n";
+
+// Re-enable validation to show it still works
+$invoice->enableTotalsValidation();
+
+try {
+    $xml = $invoice->generateXml();
+    echo "✗ This should have failed!\n";
+} catch (Exception $e) {
+    echo "✓ Validation correctly prevented mismatched totals: " . $e->getMessage() . "\n";
+}
+
+echo "\n=== Alternative: Using setTotalsValidation() ===\n";
+
+// Alternative method to control validation
+$invoice->setTotalsValidation(false);
+
+try {
+    $xml = $invoice->generateXml();
+    echo "✓ Generated successfully using setTotalsValidation(false)\n";
+} catch (Exception $e) {
+    echo "✗ Error: " . $e->getMessage() . "\n";
+}
+
+echo "\n=== Usage Summary ===\n";
+echo "1. Use ->disableTotalsValidation() to allow custom totals\n";
+echo "2. Use ->enableTotalsValidation() to restore normal validation\n";
+echo "3. Use ->setTotalsValidation(bool) for programmatic control\n";
+echo "4. All methods support method chaining\n";
+echo "5. Individual field validation (negative amounts, etc.) still applies\n";
+
+// Optional: Output the final XML
+if (isset($xml)) {
+    echo "\n=== Generated XML (Base64 Encoded) ===\n";
+    echo base64_encode($xml) . "\n";
+} 

--- a/src/JoFotaraService.php
+++ b/src/JoFotaraService.php
@@ -35,6 +35,11 @@ class JoFotaraService
 
     private string $clientSecret;
 
+    /**
+     * Whether to validate that invoice totals match calculated values from line items
+     */
+    private bool $validateTotals = true;
+
     public function __construct(string $clientId, string $clientSecret)
     {
         if (empty($clientId) || empty($clientSecret)) {
@@ -204,7 +209,7 @@ class JoFotaraService
         $this->invoiceTotals->validateSection();
 
         // Cross-section validation (totals matching items)
-        if ($this->items && $this->invoiceTotals) {
+        if ($this->items && $this->invoiceTotals && $this->validateTotals) {
             $items = $this->items->getItems();
             if (count($items) > 0) {
                 $calculatedTotals = new InvoiceTotals;
@@ -373,5 +378,39 @@ class JoFotaraService
 
         // Create a response object that can handle success, error, and auth failure responses
         return new JoFotaraResponse($result, $statusCode);
+    }
+
+    /**
+     * Disable totals validation to allow using manually set totals without
+     * cross-validation against calculated values from line items.
+     * 
+     * This is useful when you need to set exact totals that may differ
+     * from calculated values due to external business logic or rounding.
+     */
+    public function disableTotalsValidation(): self
+    {
+        $this->validateTotals = false;
+        return $this;
+    }
+
+    /**
+     * Enable totals validation (default behavior).
+     * 
+     * When enabled, manually set totals must match calculated values
+     * from line items or an exception will be thrown.
+     */
+    public function enableTotalsValidation(): self
+    {
+        $this->validateTotals = true;
+        return $this;
+    }
+
+    /**
+     * Set whether to validate totals against calculated values.
+     */
+    public function setTotalsValidation(bool $validate): self
+    {
+        $this->validateTotals = $validate;
+        return $this;
     }
 }

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -97,3 +97,163 @@ test('it should calculate payable amount correctly when item is discounted witho
         ->and($totals['taxTotalAmount'])->toBe(0.0)
         ->and($totals['payableAmount'])->toBe(280.0);
 });
+
+test('it can disable totals validation to allow manual totals', function () {
+    $invoice = new JoFotaraService('test-client-id', 'test-client-secret');
+
+    // Set up basic invoice info
+    $invoice->basicInformation()
+        ->setInvoiceId('INV-001')
+        ->setUuid('123e4567-e89b-12d3-a456-426614174000')
+        ->setIssueDate('16-02-2025')
+        ->setInvoiceType('income')
+        ->cash();
+
+    // Add required seller info
+    $invoice->sellerInformation()
+        ->setName('Seller Company')
+        ->setTin('12345678');
+
+    // Add required buyer info
+    $invoice->customerInformation()
+        ->setId('987654321', 'TIN')
+        ->setName('Customer 123');
+
+    $invoice->supplierIncomeSource('12345678');
+
+    // Add item with calculated totals: tax-exclusive=100, tax=16, tax-inclusive=116
+    $invoice->items()
+        ->addItem('1')
+        ->setQuantity(1)
+        ->setUnitPrice(100.0)
+        ->setDescription('Test Item')
+        ->tax(16);
+
+    // Disable totals validation
+    $invoice->disableTotalsValidation();
+
+    // Set different totals manually (these would normally fail validation)
+    $invoice->invoiceTotals()
+        ->setTaxExclusiveAmount(90.0)  // Different from calculated 100
+        ->setTaxInclusiveAmount(100.0) // Different from calculated 116
+        ->setTaxTotalAmount(10.0)      // Different from calculated 16
+        ->setPayableAmount(100.0);     // Different from calculated 116
+
+    // This should not throw an exception
+    expect(fn () => $invoice->generateXml())->not->toThrow(InvalidArgumentException::class);
+
+    // XML should be generated successfully
+    $xml = $invoice->generateXml();
+    expect($xml)->toContain('<cbc:TaxExclusiveAmount currencyID="JO">90.000000000</cbc:TaxExclusiveAmount>');
+    expect($xml)->toContain('<cbc:TaxInclusiveAmount currencyID="JO">100.000000000</cbc:TaxInclusiveAmount>');
+});
+
+test('it can re-enable totals validation after disabling', function () {
+    $invoice = new JoFotaraService('test-client-id', 'test-client-secret');
+
+    // Set up basic invoice info
+    $invoice->basicInformation()
+        ->setInvoiceId('INV-001')
+        ->setUuid('123e4567-e89b-12d3-a456-426614174000')
+        ->setIssueDate('16-02-2025')
+        ->setInvoiceType('income')
+        ->cash();
+
+    // Add required seller info
+    $invoice->sellerInformation()
+        ->setName('Seller Company')
+        ->setTin('12345678');
+
+    // Add required buyer info
+    $invoice->customerInformation()
+        ->setId('987654321', 'TIN')
+        ->setName('Customer 123');
+
+    $invoice->supplierIncomeSource('12345678');
+
+    // Add item
+    $invoice->items()
+        ->addItem('1')
+        ->setQuantity(1)
+        ->setUnitPrice(100.0)
+        ->setDescription('Test Item')
+        ->tax(16);
+
+    // Disable then re-enable validation
+    $invoice->disableTotalsValidation()
+             ->enableTotalsValidation();
+
+    // Set invalid totals manually
+    $invoice->invoiceTotals()
+        ->setTaxExclusiveAmount(90.0)  // Should be 100
+        ->setTaxInclusiveAmount(100.0) // Should be 116
+        ->setTaxTotalAmount(10.0)      // Should be 16
+        ->setPayableAmount(100.0);     // Should be 116
+
+    // This should throw an exception since validation is re-enabled
+    expect(fn () => $invoice->generateXml())
+        ->toThrow(InvalidArgumentException::class, 'Invoice totals do not match calculated values from line items');
+});
+
+test('it supports setTotalsValidation method', function () {
+    $invoice = new JoFotaraService('test-client-id', 'test-client-secret');
+
+    // Set up basic invoice info
+    $invoice->basicInformation()
+        ->setInvoiceId('INV-001')
+        ->setUuid('123e4567-e89b-12d3-a456-426614174000')
+        ->setIssueDate('16-02-2025')
+        ->setInvoiceType('income')
+        ->cash();
+
+    // Add required seller info
+    $invoice->sellerInformation()
+        ->setName('Seller Company')
+        ->setTin('12345678');
+
+    // Add required buyer info
+    $invoice->customerInformation()
+        ->setId('987654321', 'TIN')
+        ->setName('Customer 123');
+
+    $invoice->supplierIncomeSource('12345678');
+
+    // Add item
+    $invoice->items()
+        ->addItem('1')
+        ->setQuantity(1)
+        ->setUnitPrice(100.0)
+        ->setDescription('Test Item')
+        ->tax(16);
+
+    // Use setTotalsValidation to disable
+    $invoice->setTotalsValidation(false);
+
+    // Set different totals manually
+    $invoice->invoiceTotals()
+        ->setTaxExclusiveAmount(90.0)
+        ->setTaxInclusiveAmount(100.0)
+        ->setTaxTotalAmount(10.0)
+        ->setPayableAmount(100.0);
+
+    // Should not throw
+    expect(fn () => $invoice->generateXml())->not->toThrow(InvalidArgumentException::class);
+
+    // Re-enable with setTotalsValidation
+    $invoice->setTotalsValidation(true);
+
+    // Should now throw
+    expect(fn () => $invoice->generateXml())
+        ->toThrow(InvalidArgumentException::class, 'Invoice totals do not match calculated values from line items');
+});
+
+test('validation methods return self for method chaining', function () {
+    $invoice = new JoFotaraService('test-client-id', 'test-client-secret');
+
+    // Test method chaining
+    $result = $invoice->disableTotalsValidation()
+                     ->enableTotalsValidation()
+                     ->setTotalsValidation(false);
+
+    expect($result)->toBe($invoice);
+});


### PR DESCRIPTION
- Add validation control methods: disableTotalsValidation(), enableTotalsValidation(), setTotalsValidation()
- Allow custom totals that differ from calculated line item values
- Preserve individual field validation while disabling cross-section validation
- Support method chaining for all validation control methods
- Add comprehensive tests for new functionality
- Create example demonstrating usage with custom totals
- Update README with documentation and usage examples
- Maintain backward compatibility (validation enabled by default)

This feature enables integration with external systems that may have different calculation rules or require custom totals due to business logic.